### PR TITLE
Add safe-svg plugin

### DIFF
--- a/composer-local.json
+++ b/composer-local.json
@@ -3,13 +3,16 @@
   "description": "Greenpeace Planet 4",
   "license": "MIT",
   "require": {
-    "greenpeace/planet4-child-theme-australiapacific" : "dev-main",
-    "wpackagist-plugin/advanced-custom-fields": "5.6.2"
+    "greenpeace/planet4-child-theme-australiapacific": "dev-main",
+    "wpackagist-plugin/advanced-custom-fields": "5.6.2",
+    "wpackagist-plugin/safe-svg": "2.2.2"
   },
   "scripts": {
-		"install:plugin-wpimport": "wp plugin install --activate https://storage.googleapis.com/planet4-3rdparty-plugins/wp-all-import-pro_4.8.5.zip",
-		"site:custom": [
-			"@install:plugin-wpimport"
-		]
-	}
+    "install:plugin-wpimport": "wp plugin install --activate https://storage.googleapis.com/planet4-3rdparty-plugins/wp-all-import-pro_4.8.5.zip",
+    "activate:safe-svg": "wp plugin activate safe-svg",
+    "site:custom": [
+      "@install:plugin-wpimport",
+      "@activate:safe-svg"
+    ]
+  }
 }


### PR DESCRIPTION
[![Notion Card: Planet 4 - support SVG uploads](https://github.com/greenpeace/planet4-australiapacific/assets/13824257/1a75ada8-b6da-40bc-b349-d9c688ddf14b)](https://www.notion.so/greenpeaceaustraliapacific/Planet-4-support-SVG-uploads-e321aad593fc4cfa866988184260703c?pvs=4)

## Description

This PR adds the safe-svg plugin & allows us to upload SVGs to the media library. 

I have also added some configuration to auto-enable this plugin, but I've not been able to test this fully as our setup only allows the installation to run from the main branch, and since this isn't on the main branch I can't test this auto-enabling. 

## Acceptance Criteria

- [x] I should be able to upload an SVG to the media library of the P4 site
  - The plugin allows this by default
- [x] The SVGs that are uploaded are sanitized so they don’t contain exploits 
  - The plugin auto-sanitizes SVGs by default
