### PR TITLE
✨ Add XML sitemap generator for google plugin

### DIFF
--- a/composer-local.json
+++ b/composer-local.json
@@ -5,14 +5,17 @@
   "require": {
     "greenpeace/planet4-child-theme-australiapacific": "dev-main",
     "wpackagist-plugin/advanced-custom-fields": "5.6.2",
-    "wpackagist-plugin/safe-svg": "2.2.2"
+    "wpackagist-plugin/safe-svg": "2.2.2",
+    "wpackagist-plugin/google-sitemap-generator":"4.1.19"
   },
   "scripts": {
     "install:plugin-wpimport": "wp plugin install --activate https://storage.googleapis.com/planet4-3rdparty-plugins/wp-all-import-pro_4.8.5.zip",
     "activate:safe-svg": "wp plugin activate safe-svg",
+    "activate:google-sitemap-generator": "wp plugin activate google-sitemap-generator",
     "site:custom": [
       "@install:plugin-wpimport",
-      "@activate:safe-svg"
+      "@activate:safe-svg",
+      "@activate:google-sitemap-generator"
     ]
   }
 }


### PR DESCRIPTION
This PR adds [this plugin](https://wordpress.org/plugins/google-sitemap-generator/) to generate a sitemap. 

It is part of [this ticket](https://www.notion.so/greenpeaceaustraliapacific/P4-Install-Sitemap-xml-Plugin-fa997472a4f64f4eaa96b4d31141808c?pvs=4). This plugin generates a sitemap at:

http://www.planet4.test/sitemap.xml

![image](https://github.com/greenpeace/planet4-australiapacific/assets/13824257/450e145c-6b99-4993-b64e-a88e551f411f)

Relevant acceptance criteria:

- [x]  Install plugin on Dev site which produces a sitemap.xml file
- [x]  The XML file should have links to all the pages and posts on our site