### PR TITLE
feat: 🚀 switch hostname to www.greenpeace.org.au

### DIFF
--- a/.circleci/artifacts.yml
+++ b/.circleci/artifacts.yml
@@ -27,7 +27,7 @@ job_environments:
     WP_DB_NAME: planet4-australi_wordpress_release
     WP_STATELESS_BUCKET: planet4-australiapacific-stateless-release
   production_environment: &production_environment
-    APP_HOSTNAME: www-prod.greenpeace.org.au
+    APP_HOSTNAME: www.greenpeace.org.au
     APP_HOSTPATH:
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ job_environments:
     WP_DB_NAME: planet4-australi_wordpress_release
     WP_STATELESS_BUCKET: planet4-australiapacific-stateless-release
   production_environment: &production_environment
-    APP_HOSTNAME: www-prod.greenpeace.org.au
+    APP_HOSTNAME: www.greenpeace.org.au
     APP_HOSTPATH:
     CLOUDSQL_INSTANCE: planet4-prod
     GCLOUD_CLUSTER: planet4-production


### PR DESCRIPTION
Here we switch BACK to www.greenpeace.org.au (after a couple previous tries).

Once this gets merged, we will not be able to view the 'P4 production' site until we do DNS switchover.

See y'all on the other side. 

---
Was: 
Revert "Revert "Revert "Update production hostname"""

This reverts commit 368124484a0d34c59305bbdeebc73dc4c386144e.